### PR TITLE
Add unroll and jam support using clast.

### DIFF
--- a/include/cloog/clast.h
+++ b/include/cloog/clast.h
@@ -37,9 +37,6 @@ struct clast_term {
 #define CLAST_PARALLEL_VEC 4
 #define CLAST_PARALLEL_USER 8
 
-#define CLAST_UNROLL_NOT 0
-#define CLAST_UNROLL 1
-#define CLAST_UNROLL_JAM 2
 enum clast_red_type { clast_red_sum, clast_red_min, clast_red_max };
 struct clast_reduction {
     struct clast_expr	expr;
@@ -99,6 +96,7 @@ struct clast_user_stmt {
     struct clast_stmt *	substitutions;
 };
 
+enum clast_unroll_type {clast_no_unroll, clast_unroll, clast_unroll_and_jam};
 struct clast_for {
     struct clast_stmt	stmt;
     CloogDomain *	domain;
@@ -108,8 +106,8 @@ struct clast_for {
     cloog_int_t		stride;
     struct clast_stmt *	body;
     int parallel;
-    int unroll;
-    int ufactor;
+    enum clast_unroll_type unroll_type;
+    unsigned ufactor;
     /* Comma separated list of loop private variables for OpenMP parallelization */
     char *private_vars;
     /* Comma separated list of reduction variable/operators for OpenMP parallelization */

--- a/include/cloog/clast.h
+++ b/include/cloog/clast.h
@@ -37,6 +37,9 @@ struct clast_term {
 #define CLAST_PARALLEL_VEC 4
 #define CLAST_PARALLEL_USER 8
 
+#define CLAST_UNROLL_NOT 0
+#define CLAST_UNROLL 1
+#define CLAST_UNROLL_JAM 2
 enum clast_red_type { clast_red_sum, clast_red_min, clast_red_max };
 struct clast_reduction {
     struct clast_expr	expr;
@@ -105,6 +108,8 @@ struct clast_for {
     cloog_int_t		stride;
     struct clast_stmt *	body;
     int parallel;
+    int unroll;
+    int ufactor;
     /* Comma separated list of loop private variables for OpenMP parallelization */
     char *private_vars;
     /* Comma separated list of reduction variable/operators for OpenMP parallelization */
@@ -151,6 +156,7 @@ struct clast_for *new_clast_for(CloogDomain *domain, const char *it,
                                 struct clast_expr *LB, struct clast_expr *UB,
                                 CloogStride *stride);
 struct clast_guard *new_clast_guard(int n);
+void clast_unroll_jam(struct clast_stmt *s);
 
 void free_clast_name(struct clast_name *t);
 void free_clast_term(struct clast_term *t);


### PR DESCRIPTION
    Loops that need to be unroll jammed are marked in the clast by setting
    `clast_for->unroll` field to CLAST_UNROLL_JAM. Every marked loop is then
    unroll jammed provided the loop nest is rectangular. The implementation also
    supports multi-loop unroll jam, i.e, for a given statement, multiple loops
    enclosing the statement can be unroll jammed. The routine also supports
    unroll jamming of imperfect nested loops. The routine does not check for
    correctness of unroll jam (permutability of loop nest). It is the
    responsibility of the caller to mark the correct loops for unroll jam.

    Routines added in this commit include
            - clast_unroll_jam which is the library interface routine for
              unroll jamming the AST.
            - Routines to deep copy AST. This aids generation of clean-up code
              after unroll jam.
            - Routines to check rectangularity of the loop nest. Currently, it
              checks whether the iterator of the loop being unroll jammed
              appears in the bounds of inner loops or guards of the statements
              enclosed.