### PR TITLE
comment out document's compilation due to compatibility reason

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,12 +185,12 @@ doc:
 # *                                   Doc                                     *
 # *****************************************************************************/
 
-if HAVE_TEXI2DVI
-pdf_DATA = doc/cloog.pdf
-dist_pdf_DATA = doc/cloog.pdf
-doc/cloog.pdf: doc/cloog.texi doc/gitversion.texi
-	$(TEXI2DVI) -I $(top_builddir)/doc --pdf $< -o $@
-endif
+# if HAVE_TEXI2DVI
+# pdf_DATA = doc/cloog.pdf
+# dist_pdf_DATA = doc/cloog.pdf
+# doc/cloog.pdf: doc/cloog.texi doc/gitversion.texi
+# 	$(TEXI2DVI) -I $(top_builddir)/doc --pdf $< -o $@
+# endif
 
 doc/gitversion.texi: @GIT_INDEX@
 	echo '@set VERSION '`$(top_builddir)/genversion.sh`'' > $@


### PR DESCRIPTION
Currently, when using cloog as a submodule (in pluto), it asks for a complete texlive to compile the document. This maybe unnecessary. 

But piplib also has this issue, only updating this fork of cloog is not enough. 😄 